### PR TITLE
Fix/4.0.x/cal 689

### DIFF
--- a/calendar-webapp/src/main/webapp/templates/calendar/webui/UIMiniCalendar.gtmpl
+++ b/calendar-webapp/src/main/webapp/templates/calendar/webui/UIMiniCalendar.gtmpl
@@ -69,8 +69,10 @@
 	Calendar calendar = uicomponent.getInstanceTempCalendar();	
 	calendar.set(Calendar.DAY_OF_WEEK, calendar.getFirstDayOfWeek());
 	for(int i = 0; i < 7; i++) {	    
+    String shortDayName = _ctx.appRes("UIRepeatEventForm.label." + CalendarEvent.RP_WEEKLY_BYDAY[i]);
 	%>
-	<td><%=_ctx.appRes("UIRepeatEventForm.label." + CalendarEvent.RP_WEEKLY_BYDAY[i])%></td>
+  <div class="ShortDayName" style="dislay:none" name="$shortDayName"></div>
+	<td>$shortDayName</td>
 	<%
 	  calendar.add(Calendar.DAY_OF_WEEK, 1);
 	}


### PR DESCRIPTION
Fix description: restore div tag of ShortDayName class in UIMiniCalendar template.
