### PR TITLE
CAL-689 Pop-overs of Task/Event are not displayed or tooltips contain un...

### DIFF
--- a/calendar-webapp/src/main/webapp/templates/calendar/webui/UIMiniCalendar.gtmpl
+++ b/calendar-webapp/src/main/webapp/templates/calendar/webui/UIMiniCalendar.gtmpl
@@ -74,9 +74,10 @@
 	  /* weekstartday's values is (SUNDAY=1,MONDAY=2,...,SAT=7)
 	     the index of short day names in resource bundle is ('MO=0,'TU'=1,...,'SU=6)
 	     so given the weekstartday, the index to get the short day name in resource bundle is (weekstartday - 2) % 7 */
-	    
+	  String shortDayName = _ctx.appRes("UIRepeatEventForm.label." + CalendarEvent.RP_WEEKLY_BYDAY[(weekstartday++ - 2) % 7]);   
 	%>
-	<td><%=_ctx.appRes("UIRepeatEventForm.label." + CalendarEvent.RP_WEEKLY_BYDAY[(weekstartday++ - 2) % 7])%></td>
+  <div class="ShortDayName" style="dislay:none" name="$shortDayName"></div>
+	<td>$shortDayName</td>
 	<%
 	  calendar.add(Calendar.DAY_OF_WEEK, 1);
 	}


### PR DESCRIPTION
...unified information in different views

Fix description: restore div tag of ShortDayName class in UIMiniCalendar template.
