### PR TITLE
CAL-723 i18n of DateTimePicker

### DIFF
--- a/calendar-resources/src/main/webapp/javascript/eXo/cs/UIDateTimePicker.js
+++ b/calendar-resources/src/main/webapp/javascript/eXo/cs/UIDateTimePicker.js
@@ -20,7 +20,7 @@ this.getLang = function() {
     if (this.lang == lang) 
       return;
     this.lang = lang;
-    var languages = gj.globalEval(ajaxAsyncGetRequest(this.pathResource + this.lang.toLowerCase() + ".js", false));
+    var languages = eval(ajaxAsyncGetRequest(this.pathResource + this.lang.toLowerCase() + ".js", false));
     if (!languages || (typeof(languages) != "object")) 
       return;
   


### PR DESCRIPTION
Fix description: use eval method instead of JQuery globalEval to get translation of DateTimePicker.
