### PR TITLE
Fix/4.0.x/cal 944

### DIFF
--- a/calendar-webapp/src/main/java/org/exoplatform/calendar/CalendarUtils.java
+++ b/calendar-webapp/src/main/java/org/exoplatform/calendar/CalendarUtils.java
@@ -165,8 +165,6 @@ public class CalendarUtils {
   final public static String ITEM_NERVER = "never".intern();
   final public static String ITEM_ASK = "ask".intern();
   final public static String emailRegex = "[_A-Za-z0-9-]+(\\.[_A-Za-z0-9-]+)*@[_A-Za-z0-9-.]+";
-  /* single email format regex */
-  public static final String emailFormat = "[_A-Za-z0-9-]+@[_A-Za-z0-9-.]+";
   final public static String contactRegex = ".\\("+ emailRegex + "\\)";
 
   public final static String INVITATION_URL = "/invitation/".intern();
@@ -751,7 +749,7 @@ public class CalendarUtils {
   }
 
   public static boolean isAValidEmailAddress(String email) {
-    return email.matches(emailFormat);
+    return email.matches(emailRegex);
   }
 
   public static boolean isValidEmailAddresses(String addressList) {


### PR DESCRIPTION
Fix description: use emailRegex instead of emailFormat regex in method isAValidEmailAddress.
