### PR TITLE
CAL-905 | End date of event is updated wrongly on 31/03 when update star...

### DIFF
--- a/calendar-webapp/src/main/webapp/javascript/eXo/calendar/UICalendarPortlet.js
+++ b/calendar-webapp/src/main/webapp/javascript/eXo/calendar/UICalendarPortlet.js
@@ -3766,10 +3766,7 @@
         var monthValue = parseInt(dateFieldValue.substring(monthIndex,monthIndex + 2) - 1, 10);
         var yearIndex =   pattern.indexOf("yyyy");
         var yearValue = parseInt(dateFieldValue.substring(yearIndex,yearIndex + 4), 10);
-        var currentDate = new Date();
-        currentDate.setDate(dateValue);
-        currentDate.setMonth(monthValue);
-        currentDate.setYear(yearValue);
+        var currentDate = new Date(yearValue,monthValue,dateValue);
         return currentDate;
     }
     UICalendarPortlet.prototype.confirmOption = function(compid){


### PR DESCRIPTION
...t time
**Problem Analysis**:
* The ```setDate()``` method sets the day of the month for a specified date according to local time as it was created with the local time ```currentDate = new Date()```.

**Fix Description:**
* Do not use ```setDate(dateValue)``` to make update the end date event when choosing the start time for the current event. This will avoid any error on setting date in local context.
