### PR TITLE
CAL-1096: Group and Shared Calendars are displayed many times in Persona...

### DIFF
--- a/calendar-service/src/main/java/org/exoplatform/calendar/service/impl/JCRDataStorage.java
+++ b/calendar-service/src/main/java/org/exoplatform/calendar/service/impl/JCRDataStorage.java
@@ -341,19 +341,22 @@ public class JCRDataStorage implements DataStorage {
    * {@inheritDoc}
    */
   public List<Calendar> getUserCalendars(String username, boolean isShowAll) throws Exception {
-    String[] defaultCalendars;
     List<Calendar> calList = userCalendarCache.get(this, username);
+    List<Calendar> retList = new LinkedList<Calendar>();
 
     if (!isShowAll) {
-      defaultCalendars = getCalendarSetting(username).getFilterPrivateCalendars();
-      List<Calendar> filteredCalList = new ArrayList<Calendar>();
+      List<String> defaultCalendars = Arrays.asList(getCalendarSetting(username).getFilterPrivateCalendars());
 
       for (Calendar calendar : calList) {
-        if (!Arrays.asList(defaultCalendars).contains(calendar.getId())) filteredCalList.add(calendar);
+        if (!defaultCalendars.contains(calendar.getId())) {
+          retList.add(calendar);
+        }
       }
-      calList = filteredCalList;
+    } else {
+      retList.addAll(calList);
     }
-    return calList;
+
+    return retList;
   }
 
   /**


### PR DESCRIPTION
...l Calendar section

Problem analysis
- The calendar juzu portlet in platform and calendar service use the same object for personal calendars list in cache. When calendar juzu portlet addes or removes any item from cache but not from jcr storage, calendar service lists wrongly personal calendars.

Solution:
- Return a copy of personal calendars instead of return this list directly.