### PR TITLE
CAL-1152:CalendarRestApi events/{id}/occurrences limit is 0

### DIFF
--- a/calendar-webservice/src/main/java/org/exoplatform/calendar/ws/CalendarRestApi.java
+++ b/calendar-webservice/src/main/java/org/exoplatform/calendar/ws/CalendarRestApi.java
@@ -1584,7 +1584,7 @@ public class CalendarRestApi implements ResourceContainer {
         int fullSize = returnSize ? occMap.values().size() : -1;
         CollectionResource evData = new CollectionResource(data, fullSize);
         evData.setOffset(offset);
-        evData.setOffset(limit);
+        evData.setLimit(limit);
         
         //
         ResponseBuilder response = buildJsonP(evData, jsonp);


### PR DESCRIPTION
Fix description: Correct setLimit method for event data