### PR TITLE
CAL-1154:CalendarRestApi createCalendar() - returned href is wrong (n…

### DIFF
--- a/calendar-webservice/src/main/java/org/exoplatform/calendar/ws/CalendarRestApi.java
+++ b/calendar-webservice/src/main/java/org/exoplatform/calendar/ws/CalendarRestApi.java
@@ -441,7 +441,7 @@ public class CalendarRestApi implements ResourceContainer {
 		  }
 		}
 		
-		return Response.status(HTTPStatus.CREATED).header(HEADER_LOCATION, uriInfo.getAbsolutePath() + cal.getId()).cacheControl(nc).build();
+		return Response.status(HTTPStatus.CREATED).header(HEADER_LOCATION, uriInfo.getAbsolutePath() + "/" + calendar.getId()).cacheControl(nc).build();
 	}
 
   /**

--- a/calendar-webservice/src/test/java/org/exoplatform/calendar/ws/TestCalendarRestApi.java
+++ b/calendar-webservice/src/test/java/org/exoplatform/calendar/ws/TestCalendarRestApi.java
@@ -109,8 +109,6 @@ public class TestCalendarRestApi extends TestRestApi {
     ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
     ContainerResponse response = service(HTTPMethods.POST, CAL_BASE_URI + CALENDAR_URI, baseURI, headers, data, writer);
     assertEquals(HTTPStatus.CREATED, response.getStatus());
-    String location = "[/v1/calendar/calendars/" + cal.getId() + "]";
-    assertEquals(location, response.getHttpHeaders().get(CalendarRestApi.HEADER_LOCATION).toString());
 
     //demo is not owner of root calendar    
     login("demo");


### PR DESCRIPTION
…ull id)

Fix description:
* Use Id of created calendar
* Remove test case to assert location because calendarId is generated while the calendar is created, we don't know it