### PR TITLE
CAL-1488:Event Creation with +1 year: Time not correct (#178)

### DIFF
--- a/calendar-webapp/src/main/webapp/vue-app/calServices.js
+++ b/calendar-webapp/src/main/webapp/vue-app/calServices.js
@@ -118,11 +118,24 @@ export function getEventById(eventId, isOccur, recurId, startTime, endTime) {
 }
 
 export function saveEvent(form) {
-  const fromDate = Utils.buildUTCDate(form.event.fromDate);
-  const minute = 60;
-  fromDate.setHours(fromDate.getHours() - calConstants.SETTINGS.timezone / minute);
-  const toDate = Utils.buildUTCDate(form.event.toDate);
-  toDate.setHours(toDate.getHours() - calConstants.SETTINGS.timezone / minute);
+  const isCurrentDST = Utils.isDST(new Date());
+  const from = form.event.fromDate;
+  const isFromDST = Utils.isDST(from);
+  if(!isCurrentDST && isFromDST) {
+    from.setHours(from.getHours() - 1);
+  } else if(isCurrentDST && !isFromDST) {
+    from.setHours(from.getHours() + 1);
+  }
+  const fromDate = new Date(Date.UTC(from.getFullYear(), from.getMonth(), from.getDate(), from.getHours() - calConstants.SETTINGS.timezone/ calConstants.ONE_HOUR_MINUTES, from.getMinutes(), from.getSeconds()));
+  
+  const to = form.event.toDate;
+  const isToDST = Utils.isDST(to);
+  if(!isCurrentDST && isToDST) {
+    to.setHours(to.getHours() - 1);
+  } else if(isCurrentDST && !isToDST) {
+    to.setHours(to.getHours() + 1);
+  }
+  const toDate = new Date(Date.UTC(to.getFullYear(), to.getMonth(), to.getDate(), to.getHours() - calConstants.SETTINGS.timezone/ calConstants.ONE_HOUR_MINUTES, to.getMinutes(), to.getSeconds()));
 
   const event = {
     id: form.event.id,

--- a/calendar-webapp/src/main/webapp/vue-app/model/utils.js
+++ b/calendar-webapp/src/main/webapp/vue-app/model/utils.js
@@ -91,12 +91,15 @@ export default {
       return null;
     }
   },
-
-  buildUTCDate(date) {
-    const result = new Date();
-    result.setUTCFullYear(date.getFullYear(), date.getMonth(), date.getDate());
-    result.setUTCHours(date.getHours(), date.getMinutes(), date.getSeconds(), date.getMilliseconds());
-    return result;
+  
+  //  Since no country observes DST that lasts for 7 months, in an area that observes DST the offset from UTC time in January will be different to the one in July.
+  // So we use the timezone offset between January and July to determine the DST since JavaScript always returns a greater value during Standard Time.
+  isDST(date) {
+    const jan = 0;
+    const jul = 6;
+    const janOffset = new Date(date.getFullYear(), jan, 1).getTimezoneOffset();
+    const julOffset = new Date(date.getFullYear(), jul, 1).getTimezoneOffset();
+    return Math.max(janOffset, julOffset) !== date.getTimezoneOffset();
   },
 
   getTimezoneOffset() {


### PR DESCRIPTION
Make sure to use the Calendar timezone instead of system timezone and to consider the DST for creating events on long term.