### PR TITLE
CAL-1488-3: Add needed js constants to make sure saveEvent function works fine.

### DIFF
--- a/calendar-webapp/src/main/webapp/vue-app/calConstants.js
+++ b/calendar-webapp/src/main/webapp/vue-app/calConstants.js
@@ -13,5 +13,8 @@ export const calConstants = {
   NO_REPEAT: 'norepeat',
   WEEK_DAYS: ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'],
   MAX_UPLOAD_FILES: 10,
-  MAX_UPLOAD_SIZE: 10
+  MAX_UPLOAD_SIZE: 10,
+  ONE_HOUR_MINUTES: 60,
+  ONE_DAY_HOURS: 24,
+  ONE_WEEK_DAYS: 7
 };


### PR DESCRIPTION
The issue is that saveEvent in Calendar app is not working. After digging i found out that the calConstants.js is missing constants that are used in saveEvent function under calServices.js, so i added them.
This fix is only needed for branch stable/5.2.x.